### PR TITLE
Fix rsync_opts handling with ansible 2.3+

### DIFF
--- a/tasks/deploy-git-repo.yml
+++ b/tasks/deploy-git-repo.yml
@@ -35,7 +35,7 @@
 
 - name: "Repo {{ git_repo.name }}: Generate rsync_opts"
   set_fact:
-    git_repo_rsync_opts: "{{ git_repo_rsync_opts }} + ['--exclude {{ item }}']"
+    git_repo_rsync_opts: "{{ git_repo_rsync_opts }} + ['--exclude'] + ['{{ item }}']"
   with_items: "{{ git_repo.excludes }}"
   when: git_repo.excludes | default([]) | length > 0
 


### PR DESCRIPTION
Every option should be a list item, and this includes options that have arguments. Here I chose to keep the space, but it could have been a single option with '='

Fixes #1 